### PR TITLE
When creating the node schedule, pass the job time zone

### DIFF
--- a/lib/NestDistributedSchedule.ts
+++ b/lib/NestDistributedSchedule.ts
@@ -22,6 +22,7 @@ export abstract class NestDistributedSchedule {
                     const _job = schedule.scheduleJob({
                         startTime: job.startTime,
                         endTime: job.endTime,
+                        tz: job.tz,
                         rule: job.cron
                     }, async () => {
                         const executor = new JobExecutor(configs, configs.logger);


### PR DESCRIPTION
The documentation has an example of how to configure a timezone, and there is a tz field in CronOptions, but this is not passed to node-schedule when creating the schedule. 

I have performed some simple tests, and with this change, the timezone configured in CronOptions is respected - without it the time configured is always your local server time, and configured timezones are ignored.