### PR TITLE
feat: add logic to get jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,13 +223,13 @@ export class AppModule {
 
 Register schedule module.
 
-| field | type | required | description |
-| --- | --- | --- | --- |
-| config.enable | boolean | false | default is true, when false, the job will not execute |
-| config.maxRetry | number | false |  the max retry count, default is -1 not retry |
-| config.retryInterval | number | false | the retry interval, default is 5000 |
-| config.logger | LoggerService \| boolean | false | custom schedule logger, default is console |
-| config.waiting | boolean | false | the scheduler will not schedule job when this job is running, if waiting is true |
+| field                | type                     | required | description                                                                      |
+| -------------------- | ------------------------ | -------- | -------------------------------------------------------------------------------- |
+| config.enable        | boolean                  | false    | default is true, when false, the job will not execute                            |
+| config.maxRetry      | number                   | false    | the max retry count, default is -1 not retry                                     |
+| config.retryInterval | number                   | false    | the retry interval, default is 5000                                              |
+| config.logger        | LoggerService \| boolean | false    | custom schedule logger, default is console                                       |
+| config.waiting       | boolean                  | false    | the scheduler will not schedule job when this job is running, if waiting is true |
 
 ### class Schedule
 
@@ -237,51 +237,59 @@ Register schedule module.
 
 Schedule a cron job.
 
-| field | type | required | description |
-| --- | --- | --- | --- |
-| key | string | true | The unique job key |
-| cron | string | true | The cron expression |
-| callback | () => Promise&lt;boolean&gt; | boolean | If return true in callback function, the schedule will cancel this job immediately |
-| config.startTime | Date | false | The start time of this job |
-| config.endTime | Date | false | The end time of this job |
-| config.enable | boolean | false | default is true, when false, the job will not execute |
-| config.maxRetry | number | false |  the max retry count, default is -1 not retry |
-| config.retryInterval | number | false | the retry interval, default is 5000 |
-| config.waiting | boolean | false | the scheduler will not schedule job when this job is running, if waiting is true |
-| config.immediate | boolean | false | running job immediately |
+| field                | type                         | required | description                                                                        |
+| -------------------- | ---------------------------- | -------- | ---------------------------------------------------------------------------------- |
+| key                  | string                       | true     | The unique job key                                                                 |
+| cron                 | string                       | true     | The cron expression                                                                |
+| callback             | () => Promise&lt;boolean&gt; | boolean  | If return true in callback function, the schedule will cancel this job immediately |
+| config.startTime     | Date                         | false    | The start time of this job                                                         |
+| config.endTime       | Date                         | false    | The end time of this job                                                           |
+| config.enable        | boolean                      | false    | default is true, when false, the job will not execute                              |
+| config.maxRetry      | number                       | false    | the max retry count, default is -1 not retry                                       |
+| config.retryInterval | number                       | false    | the retry interval, default is 5000                                                |
+| config.waiting       | boolean                      | false    | the scheduler will not schedule job when this job is running, if waiting is true   |
+| config.immediate     | boolean                      | false    | running job immediately                                                            |
 
 #### scheduleIntervalJob(key: string, interval: number, callback: JobCallback, config?: IJobConfig)
 
 Schedule a interval job.
 
-| field | type | required | description |
-| --- | --- | --- | --- |
-| key | string | true | The unique job key |
-| interval | number | true | milliseconds |
-| callback | () => Promise&lt;boolean&gt; | boolean | If return true in callback function, the schedule will cancel this job immediately |
-| config.enable | boolean | false | default is true, when false, the job will not execute |
-| config.maxRetry | number | false |  the max retry count, default is -1 not retry |
-| config.retryInterval | number | false | the retry interval, default is 5000 |
-| config.waiting | boolean | false | the scheduler will not schedule job when this job is running, if waiting is true |
-| config.immediate | boolean | false | running job immediately |
+| field                | type                         | required | description                                                                        |
+| -------------------- | ---------------------------- | -------- | ---------------------------------------------------------------------------------- |
+| key                  | string                       | true     | The unique job key                                                                 |
+| interval             | number                       | true     | milliseconds                                                                       |
+| callback             | () => Promise&lt;boolean&gt; | boolean  | If return true in callback function, the schedule will cancel this job immediately |
+| config.enable        | boolean                      | false    | default is true, when false, the job will not execute                              |
+| config.maxRetry      | number                       | false    | the max retry count, default is -1 not retry                                       |
+| config.retryInterval | number                       | false    | the retry interval, default is 5000                                                |
+| config.waiting       | boolean                      | false    | the scheduler will not schedule job when this job is running, if waiting is true   |
+| config.immediate     | boolean                      | false    | running job immediately                                                            |
 
 #### scheduleTimeoutJob(key: string, timeout: number, callback: JobCallback, config?: IJobConfig)
 
 Schedule a timeout job.
 
-| field | type | required | description |
-| --- | --- | --- | --- |
-| key | string | true | The unique job key |
-| timeout | number | true | milliseconds |
-| callback | () => Promise&lt;boolean&gt; | boolean | If return true in callback function, the schedule will cancel this job immediately |
-| config.enable | boolean | false | default is true, when false, the job will not execute |
-| config.maxRetry | number | false |  the max retry count, default is -1 not retry |
-| config.retryInterval | number | false | the retry interval, default is 5000 |
-| config.immediate | boolean | false | running job immediately |
+| field                | type                         | required | description                                                                        |
+| -------------------- | ---------------------------- | -------- | ---------------------------------------------------------------------------------- |
+| key                  | string                       | true     | The unique job key                                                                 |
+| timeout              | number                       | true     | milliseconds                                                                       |
+| callback             | () => Promise&lt;boolean&gt; | boolean  | If return true in callback function, the schedule will cancel this job immediately |
+| config.enable        | boolean                      | false    | default is true, when false, the job will not execute                              |
+| config.maxRetry      | number                       | false    | the max retry count, default is -1 not retry                                       |
+| config.retryInterval | number                       | false    | the retry interval, default is 5000                                                |
+| config.immediate     | boolean                      | false    | running job immediately                                                            |
 
 #### cancelJob(key: string)
 
 Cancel job.
+
+#### getJobIds(): string[]
+
+Get list of all job ids
+
+#### getJobById(id: string):IJob
+
+Get job by id
 
 
 ## Decorators
@@ -290,44 +298,44 @@ Cancel job.
 
 Schedule a cron job.
 
-| field | type | required | description |
-| --- | --- | --- | --- |
-| expression | string | true | the cron expression |
-| config.key | string | false | The unique job key |
-| config.startTime | Date | false | the job's start time |
-| config.endTime | Date | false | the job's end time |
-| config.enable | boolean | false | default is true, when false, the job will not execute |
-| config.maxRetry | number | false |  the max retry count, default is -1 not retry |
-| config.retryInterval | number | false | the retry interval, default is 5000 |
-| config.waiting | boolean | false | the scheduler will not schedule job when this job is running, if waiting is true |
-| config.immediate | boolean | false | running job immediately |
+| field                | type    | required | description                                                                      |
+| -------------------- | ------- | -------- | -------------------------------------------------------------------------------- |
+| expression           | string  | true     | the cron expression                                                              |
+| config.key           | string  | false    | The unique job key                                                               |
+| config.startTime     | Date    | false    | the job's start time                                                             |
+| config.endTime       | Date    | false    | the job's end time                                                               |
+| config.enable        | boolean | false    | default is true, when false, the job will not execute                            |
+| config.maxRetry      | number  | false    | the max retry count, default is -1 not retry                                     |
+| config.retryInterval | number  | false    | the retry interval, default is 5000                                              |
+| config.waiting       | boolean | false    | the scheduler will not schedule job when this job is running, if waiting is true |
+| config.immediate     | boolean | false    | running job immediately                                                          |
 
 ### Interval(milliseconds: number, config?: IJobConfig): MethodDecorator
 
 Schedule a interval job.
 
-| field | type | required | description |
-| --- | --- | --- | --- |
-| milliseconds | number | true | milliseconds |
-| config.key | string | false | The unique job key |
-| config.enable | boolean | false | default is true, when false, the job will not execute |
-| config.maxRetry | number | false |  the max retry count, default is -1 not retry |
-| config.retryInterval | number | false | the retry interval, default is 5000 |
-| config.waiting | boolean | false | the scheduler will not schedule job when this job is running, if waiting is true |
-| config.immediate | boolean | false | running job immediately |
+| field                | type    | required | description                                                                      |
+| -------------------- | ------- | -------- | -------------------------------------------------------------------------------- |
+| milliseconds         | number  | true     | milliseconds                                                                     |
+| config.key           | string  | false    | The unique job key                                                               |
+| config.enable        | boolean | false    | default is true, when false, the job will not execute                            |
+| config.maxRetry      | number  | false    | the max retry count, default is -1 not retry                                     |
+| config.retryInterval | number  | false    | the retry interval, default is 5000                                              |
+| config.waiting       | boolean | false    | the scheduler will not schedule job when this job is running, if waiting is true |
+| config.immediate     | boolean | false    | running job immediately                                                          |
 
 ### Timeout(milliseconds: number, config?: IJobConfig): MethodDecorator
 
 Schedule a timeout job.
 
-| field | type | required | description |
-| --- | --- | --- | --- |
-| milliseconds | number | true | milliseconds |
-| config.key | string | false | The unique job key |
-| config.enable | boolean | false | default is true, when false, the job will not execute |
-| config.maxRetry | number | false |  the max retry count, default is -1 not retry |
-| config.retryInterval | number | false | the retry interval, default is 5000 |
-| config.immediate | boolean | false | running job immediately |
+| field                | type    | required | description                                           |
+| -------------------- | ------- | -------- | ----------------------------------------------------- |
+| milliseconds         | number  | true     | milliseconds                                          |
+| config.key           | string  | false    | The unique job key                                    |
+| config.enable        | boolean | false    | default is true, when false, the job will not execute |
+| config.maxRetry      | number  | false    | the max retry count, default is -1 not retry          |
+| config.retryInterval | number  | false    | the retry interval, default is 5000                   |
+| config.immediate     | boolean | false    | running job immediately                               |
 
 ### InjectSchedule(): PropertyDecorator
 

--- a/lib/executor.ts
+++ b/lib/executor.ts
@@ -13,7 +13,8 @@ export class Executor {
   async execute(
     jobKey: string,
     callback: () => Promise<Stop> | Stop,
-    tryLock: Promise<TryLock> | TryLock,
+    args: any[],
+    tryLock?: Promise<TryLock> | TryLock,
   ): Promise<Stop> {
     let release;
     if (typeof tryLock === 'function') {
@@ -32,7 +33,7 @@ export class Executor {
       }
     }
 
-    const result = await this.run(jobKey, callback);
+    const result = await this.run(jobKey, callback, args);
 
     try {
       typeof release === 'function' ? release() : void 0;
@@ -49,10 +50,11 @@ export class Executor {
 
   private async run(
     jobKey: string,
-    callback: () => Promise<Stop> | Stop,
+    callback: (...args: any[]) => Promise<Stop> | Stop,
+    args: any[],
   ): Promise<Stop> {
     try {
-      const result = await callback();
+      const result = await callback(...args);
       this.clear();
       return result;
     } catch (e) {

--- a/lib/schedule.ts
+++ b/lib/schedule.ts
@@ -24,8 +24,9 @@ export class Schedule {
     cron: string,
     callback: JobCallback,
     config?: ICronJobConfig,
+    tryLock?: Promise<TryLock> | TryLock,
   ) {
-    this.scheduler.scheduleCronJob(key, cron, callback, config);
+    this.scheduler.scheduleCronJob(key, cron, callback, config, tryLock);
   }
 
   public scheduleIntervalJob(
@@ -33,8 +34,15 @@ export class Schedule {
     interval: number,
     callback: JobCallback,
     config?: IJobConfig,
+    tryLock?: Promise<TryLock> | TryLock,
   ) {
-    this.scheduler.scheduleIntervalJob(key, interval, callback, config);
+    this.scheduler.scheduleIntervalJob(
+      key,
+      interval,
+      callback,
+      config,
+      tryLock,
+    );
   }
 
   public scheduleTimeoutJob(
@@ -42,7 +50,22 @@ export class Schedule {
     timeout: number,
     callback: JobCallback,
     config?: IJobConfig,
+    tryLock?: Promise<TryLock> | TryLock,
   ) {
-    this.scheduler.scheduleTimeoutJob(key, timeout, callback, config);
+    this.scheduler.scheduleTimeoutJob(key, timeout, callback, config, tryLock);
+  }
+
+  /**
+   * Get all registered jobs
+   */
+  public getJobIds() {
+    return this.scheduler.getJobIds();
+  }
+
+  /**
+   * Get jobs by ids
+   */
+  public getJobById(id: string) {
+    return this.scheduler.getJobById(id);
   }
 }

--- a/lib/scheduler.ts
+++ b/lib/scheduler.ts
@@ -72,6 +72,21 @@ export class Scheduler {
     }
   }
 
+  private static parseDate(inp: any): Date {
+    const ret = new Date(inp);
+    if (Object.prototype.toString.call(ret) === '[object Date]') {
+      // it is a date
+      if (isNaN(ret.getTime())) {
+        // d.valueOf() could also work
+        return undefined;
+      } else {
+        return ret;
+      }
+    } else {
+      return undefined;
+    }
+  }
+
   public static scheduleCronJob(
     key: string,
     cron: string,
@@ -80,10 +95,12 @@ export class Scheduler {
     tryLock?: Promise<TryLock> | TryLock,
   ) {
     const configs = Object.assign({}, defaults, config);
+    const startTime = this.parseDate(config && config.startTime);
+    const endTime = this.parseDate(config && config.endTime);
     const instance = schedule.scheduleJob(
       {
-        start: config.startTime,
-        end: config.endTime,
+        start: startTime,
+        end: endTime,
         rule: cron,
       },
       async () => {
@@ -205,5 +222,19 @@ export class Scheduler {
     if (needStop) {
       this.cancelJob(key);
     }
+  }
+
+  /**
+   * Get all registered jobs
+   */
+  public static getJobIds() {
+    return [...this.jobs.keys()];
+  }
+
+  /**
+   * Get jobs by ids
+   */
+  public static getJobById(id: string) {
+    return this.jobs.has(id) ? this.jobs.get(id) : undefined;
   }
 }

--- a/lib/scheduler.ts
+++ b/lib/scheduler.ts
@@ -103,7 +103,7 @@ export class Scheduler {
         end: endTime,
         rule: cron,
       },
-      async () => {
+      async (...args: any[]) => {
         const job = this.jobs.get(key);
         if (configs.waiting && job.status !== READY) {
           return false;
@@ -116,7 +116,7 @@ export class Scheduler {
         );
 
         job.status = READY;
-        const needStop = await executor.execute(key, cb, tryLock);
+        const needStop = await executor.execute(key, cb, args, tryLock);
         if (needStop) {
           this.cancelJob(key);
         }


### PR DESCRIPTION
**Changes**
- Add `tryLock` argument for all the job schedule function. This argument is available in `Scheduler` but not being use in `Schedule` service
- Add `getJobIds` and `getJobById`. Just in case that we need to manually control the job.
- Update the readme
- For the cron job, safely use start time and end time
- Allow pass arguments when invoke a job. This will be useful when you want to manually trigger a job