### PR TITLE
Fixes for dynamic cron job issue while running the application with this plugin

### DIFF
--- a/lib/scheduler.ts
+++ b/lib/scheduler.ts
@@ -16,9 +16,7 @@ export class Scheduler {
   public static queueJob(job: IJob) {
     if (this.jobs.has(job.key)) {
       throw new JobRepeatException(
-        `The job ${
-          job.key
-        } has already exists, please set key attribute rename it`,
+        `The job ${job.key} has already exists, please set key attribute rename it`,
       );
     }
     const config = Object.assign({}, defaults, job.config);
@@ -82,8 +80,10 @@ export class Scheduler {
     const configs = Object.assign({}, defaults, config);
     const instance = schedule.scheduleJob(
       {
-        start: config.startTime,
-        end: config.endTime,
+        // BUG: Triggered undefined when the params were optional
+        start: config ? config.startTime : null,
+        // BUG: Triggered undefined when the params were optional
+        end: config ? config.endTime : null,
         rule: cron,
       },
       async () => {

--- a/samples/app.module.ts
+++ b/samples/app.module.ts
@@ -4,6 +4,7 @@ import { DistributedScheduleService } from './distributed-schedule.service';
 import { NestcloudSchedule } from './nestcloud.schedule';
 import { DynamicScheduleService } from './dynamic-schedule.service';
 import { ScheduleModule } from 'nest-schedule';
+import { DynamicCronService } from './dynamic-cron.service';
 
 @Module({
   imports: [ScheduleModule.register({})],
@@ -12,6 +13,7 @@ import { ScheduleModule } from 'nest-schedule';
     DistributedScheduleService,
     NestcloudSchedule,
     DynamicScheduleService,
+    DynamicCronService,
   ],
 })
 export class AppModule {}

--- a/samples/dynamic-cron.service.ts
+++ b/samples/dynamic-cron.service.ts
@@ -1,0 +1,15 @@
+import { InjectSchedule, Schedule } from 'nest-schedule';
+import { Injectable, OnModuleInit } from '@nestjs/common';
+
+@Injectable()
+export class DynamicCronService implements OnModuleInit {
+  constructor(@InjectSchedule() private readonly schedule: Schedule) {}
+
+  onModuleInit(): any {
+    // Activates every 10 seconds
+    this.schedule.scheduleCronJob('custom_cron_job', '*/10 * * * * *', () => {
+      console.log('executing my custom cron job');
+      return false;
+    });
+  }
+}


### PR DESCRIPTION
This issue fixes the error while starting the server using Dynamic Schedule Job using cron

```typescript
    this.schedule.scheduleCronJob('custom_cron_job', '*/10 * * * * *', () => {
      console.log('executing cron job');
      return false;
    });
```

fixes the bug 

```
(node:45897) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'startTime' of undefined
```