### PR TITLE
Fix: waiting of cron jobs does not work

### DIFF
--- a/lib/scheduler.ts
+++ b/lib/scheduler.ts
@@ -103,9 +103,10 @@ export class Scheduler {
       job.status = RUNNING;
 
       const executor = new Executor(configs);
+      const needStop = await executor.execute(key, cb, tryLock);
 
       job.status = READY;
-      const needStop = await executor.execute(key, cb, tryLock);
+      
       if (needStop) {
         this.cancelJob(key);
       }


### PR DESCRIPTION
This PR fixes waiting of cron jobs. It does not work due to incorrect job's status (job becomes ready before execution)